### PR TITLE
Update DomainPasswordSpray.ps1

### DIFF
--- a/DomainPasswordSpray.ps1
+++ b/DomainPasswordSpray.ps1
@@ -552,7 +552,7 @@ function Get-ObservationWindow($DomainEntry)
 {
     # Get account lockout observation window to avoid running more than 1
     # password spray per observation window.
-    $lockObservationWindow_attr = $DomainEntry.Properties['lockoutObservationWindow']
-    $observation_window = $DomainEntry.ConvertLargeIntegerToInt64($lockObservationWindow_attr.Value) / -600000000
+    $lockObservationWindow_attr = ([ADSI]$DomainEntry).Properties['lockoutObservationWindow']
+    $observation_window = ([ADSI]$DomainEntry).ConvertLargeIntegerToInt64($lockObservationWindow_attr.Value) / -600000000
     return $observation_window
 }


### PR DESCRIPTION
$DomainEntry was being passed in as a String object. Needs to be cast to an ADSI object before referencing the object's properties and methods. This behavior was found to be causing errors on Windows Server 2008 R2.